### PR TITLE
expose public method SetGocloak to allow overriding gocloak instance

### DIFF
--- a/session.go
+++ b/session.go
@@ -43,6 +43,13 @@ func PrematureRefreshThresholdOption(accessToken, refreshToken time.Duration) Ca
 	}
 }
 
+func SetGocloak(gc gocloak.GoCloak) CallOption {
+	return func(gcs *goCloakSession) error {
+		gcs.gocloak = gc
+		return nil
+	}
+}
+
 type goCloakSession struct {
 	clientID                              string
 	clientSecret                          string


### PR DESCRIPTION
In recent major version releases of Keycloak, the '/auth' context path is removed ([docs](https://www.keycloak.org/migration/migrating-to-quarkus#:~:text=/auth%20removed%20from%20the%20default%20context%20path)). In order to adapt this change I borrowed the idea from [this issue](https://github.com/Nerzal/gocloak/issues/346#issuecomment-1087955684) allowing us to pass a gocloak instance instead of the default one, which forces to add '/auth' to the url.